### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Install KDevelop, Kate and (optionally) additional language support plugins
 Launch D-Bus
 
 * mkdir -p ~/Library/LaunchAgents
-* cp /usr/local/Cellar/d-bus/&lt;version&gt;/org.freedesktop.dbus-session.plist ~/Library/LaunchAgents/
+* ln -s /usr/local/opt/d-bus/org.freedesktop.dbus-session.plist ~/Library/LaunchAgents/
 * launchctl load -w ~/Library/LaunchAgents/org.freedesktop.dbus-session.plist
 
 Update system configuration:


### PR DESCRIPTION
It would probably be nicer to give instructions to create a symlink to the LaunchAgent, and the latest version, rather than copying the current one. So
`cp /usr/local/Cellar/d-bus/<version>/org.freedesktop.dbus-session.plist ~/Library/LaunchAgents/`
becomes
`ln -s /usr/local/opt/d-bus/org.freedesktop.dbus-session.plist ~/Library/LaunchAgents/`

(because `/usr/local/opt/d-bus` is a symlink to `/usr/local/Cellar/d-bus/<version>`).

That way there will be no need to update should it ever get changed in a D-Bus update.
