### PR TITLE
Updated formulae for digikam and marble. Based on #9

### DIFF
--- a/digikam.rb
+++ b/digikam.rb
@@ -1,0 +1,69 @@
+require File.join(File.dirname(__FILE__), 'base_kde_formula')
+
+class Digikam < BaseKdeFormula
+  homepage 'http://www.digikam.org/'
+  url "http://download.kde.org/stable/digikam/digikam-4.1.0.tar.bz2"
+  sha1 "b2cd7acca4e9b4d7924a5c5f76009846b8b3b6e0"
+
+  # Ref: https://trac.macports.org/browser/trunk/dports/kde/digikam/Portfile
+  # Digikam and kipi-plugins dependencies
+  depends_on 'kdelibs'
+  depends_on 'kdepimlibs'
+  depends_on 'qt'
+  depends_on 'libtiff'
+  #depends_on 'libjpg'
+  depends_on 'libpng'
+  depends_on 'opencv'
+  depends_on 'marble'
+  depends_on 'exiv2'
+
+  # kipi-plugins dependencies
+  #depends_on 'expat'
+  depends_on 'gdk-pixbuf'
+  #depends_on 'libgpod'
+  depends_on 'libxml2'
+  depends_on 'libxslt'
+  depends_on 'qca'
+  depends_on 'qjson'
+  depends_on 'imagemagick'
+  depends_on 'eigen'
+
+  # Digikam dependencies
+  #depends_on 'boost'
+  #depends_on 'gettext'
+  depends_on 'glib'
+  depends_on 'lensfun'
+  depends_on 'libgphoto2'
+  depends_on 'liblqr'
+  depends_on 'libusb'
+  depends_on 'jasper'
+  depends_on 'shared-desktop-ontologies'
+  depends_on 'libraw'
+  depends_on 'sane-backends'
+
+  # If building with external KDEGraphics libs
+  #depends_on 'libkdcraw'
+  #depends_on 'libkexiv2'
+  #depends_on 'libkipi'
+  #depends_on 'libksane'
+
+  # Runtime dependencies
+  depends_on 'kde-runtime'
+  depends_on 'oxygen-icons'
+
+  def patches
+    # Build fails with 'Unknown CMake command "FLEX_TARGET".'
+    # Suspect missing 'hugin' package. Disable panorama plugin for now:
+    {:p0 => 'https://gist.github.com/tlvince/8004513/raw/b61f7213d56058e7d97f00c0bfbf9701eea03aac/disable-panorama.diff'}
+  end
+
+  def extra_cmake_args
+    [
+      '-DDIGIKAMSC_USE_PRIVATE_KDEGRAPHICS=on',
+      '-DDIGIKAMSC_COMPILE_DOC=off'
+    ]
+  end
+
+  kde_build_deps
+end
+

--- a/marble.rb
+++ b/marble.rb
@@ -1,0 +1,20 @@
+require File.join(File.dirname(__FILE__), 'base_kde_formula')
+
+class Marble < BaseKdeFormula
+  homepage 'http://marble.kde.org/'
+  url "http://download.kde.org/stable/4.13.2/src/marble-4.13.2.tar.xz"
+  sha1 "007dbe5abc646a1c54b2661fa417db8f63f45b3a"
+
+  def patches
+    # Preserve CMake files (needed by Digikam)
+    {:p0 => 'https://gist.github.com/tlvince/7960812/raw/f96e2f2d1a681c6329da9fc9ac3dbf6c18577b0a/marble-homebrew-cmakelists.diff'}
+  end
+
+  def extra_cmake_args
+    # Prevent 'marble-qt.app' from being installed in '/usr/local'
+    "-DCMAKE_INSTALL_PREFIX=#{prefix}"
+  end
+
+  kde_build_deps
+end
+


### PR DESCRIPTION
Updated urls and sha1s, added exiv2 as dependency for digikam.

For me, marble produces a conflict with shared-mime-info and it doesn't
link the FindMarble.cmake file as it should.
No idea how to address those.

DigiKam seems to work, except for the table view.
