### PR TITLE
fix adymo/homebrew-kde#40 and similar issue with pg-qt package

### DIFF
--- a/grantlee.rb
+++ b/grantlee.rb
@@ -2,9 +2,9 @@ require File.join(File.dirname(__FILE__), 'base_kde_formula')
 
 class Grantlee < BaseKdeFormula
   homepage 'http://grantlee.org/'
-  version '0.3.0'
-  url 'http://gitorious.org/grantlee/grantlee/archive-tarball/master'
-  sha1 '9f64b3d5579ae32085fa459e44581f21b08469d6'
+  version '0.5.1'
+  url 'https://gitorious.org/grantlee/grantlee/archive/v0.5.1.tar.gz'
+  sha1 '4b7e16e1db9e8bc88af1283e0d5d4129c224edc2'
 
   kde_build_deps
   depends_on 'qt' => ["with-d-bus", "with-qt3support"]

--- a/kdevelop-pg-qt.rb
+++ b/kdevelop-pg-qt.rb
@@ -2,7 +2,7 @@ require File.join(File.dirname(__FILE__), 'base_kde_formula')
 
 class KdevelopPgQt < BaseKdeFormula
   homepage 'http://kdevelop.org/'
-  url 'git://anongit.kde.org/kdevelop-pg-qt'
+  url 'http://anongit.kde.org/kdevelop-pg-qt', :using => :git, :branch => "1.1"
   sha1 '7c2b77c7e81d82368285ea38cf1b5cf8160a46f0'
 
   depends_on 'kdelibs'


### PR DESCRIPTION
Attempts to fix `grantlee` and `kdevelop-pg-qt` version issues by setting most recent compatible stable version for each. Should also fix #40.
