### PR TITLE
clone grantlee instead of downloading archive from gitorious

### DIFF
--- a/grantlee.rb
+++ b/grantlee.rb
@@ -3,8 +3,7 @@ require File.join(File.dirname(__FILE__), 'base_kde_formula')
 class Grantlee < BaseKdeFormula
   homepage 'http://grantlee.org/'
   version '0.5.1'
-  url 'https://gitorious.org/grantlee/grantlee/archive/v0.5.1.tar.gz'
-  sha1 '0c89a65397e1e8402e12f586ca5f63309b5e041c'
+  url 'https://gitorious.org/grantlee/grantlee.git', :using => :git, :tag => "v0.5.1"
   head 'https://gitorious.org/grantlee/grantlee.git'
 
   kde_build_deps


### PR DESCRIPTION
This should fix #40 issue where checksum was different at various
times for grantlee tar.gz archive even for the same tag by avoiding
the download and using git clone of that same tag instead.