### PR TITLE
Fix strigi when building against clang 3.5 or later.

### DIFF
--- a/strigi.rb
+++ b/strigi.rb
@@ -66,3 +66,18 @@ __END__
  pkg_check_modules(CLUCENE1 libclucene-core)
  
 +SET(CLUCENE1_LDFLAGS ${CLUCENE1_LDFLAGS} -lclucene-shared)
+--- a/strigidaemon/bin/daemon/xesam/xesamsearch.h
++++ b/strigidaemon/bin/daemon/xesam/xesamsearch.h
+@@ -40,10 +40,10 @@
+     XesamSearch(XesamSession& s, const std::string& n,
+         const std::string& query);
+     XesamSearch(const XesamSearch&);
+-    XesamSearch(Private* p);
++    explicit XesamSearch(Private* p);
+     ~XesamSearch();
+     void operator=(const XesamSearch& xs);
+-    bool operator==(const XesamSearch& xs) { return p == xs.p; }
++    bool operator==(const XesamSearch& xs) const { return p == xs.p; }
+     void startSearch();
+     void getHitCount(void* msg);
+     void getHits(void* msg, uint32_t num);


### PR DESCRIPTION
This fixes issue #57 (strigi doesn't build with clang 3.5+).

See https://llvm.org/bugs/show_bug.cgi?id=23274 for further details about this issue.