### PR TITLE
Use absolute path to dependency to avoid conflicts

### DIFF
--- a/calligra.rb
+++ b/calligra.rb
@@ -17,7 +17,7 @@ class Calligra < Formula
   depends_on "boost" => :build
   depends_on "xz" => :build
 
-  depends_on "oxygen-icons"
+  depends_on "adymo/kde/oxygen-icons"
   depends_on "qca"
   depends_on "gsl"
   depends_on "little-cms2"


### PR DESCRIPTION
There is a package named oxygen-icons in the hombrew main repo which conflicts with this package and causes an error message on install.  Specifying the exact location of the package resolves this.